### PR TITLE
(maint) Ensure that bin/maintainers sets up bundler

### DIFF
--- a/bin/maintainers
+++ b/bin/maintainers
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'bundler/setup'
 require 'maintainers'
 
 cli = Maintainers::CLI.new


### PR DESCRIPTION
![](https://d3ui957tjb5bqd.cloudfront.net/images/screenshots/products/6/65/65905/vintage-bundle-logos-icons-textures-f.png?1389903529)

Prior to this, for a developer working locally in the checked out repository,
running `bin/maintainers` would generate an error about being unable to load
the maintainers library. Running with `bundle exec bin/maintainers` would work
properly.

As we're using `bundler/setup` in `bin/console`, it seems the most consistent
way to fix this problem would be to `require 'bundler/setup'` in
`bin/maintainers`, rather than forcing developers to use `bundle exec` in some
places and not others.

cc @kylog 
