### PR TITLE
Catch schema exception

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,10 +4,14 @@
   "issues": "https://github.com/puppetlabs/maintainers/issues",
   "people": [
     {
-      "github": "kylog",
-      "email": "kylo@puppet.com",
-      "name": "Kylo Ginsberg"
+      "github": "mikaelsmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
     }
+    {
+      "github": "theshanx",
+      "email": "tiffany@puppet.com",
+      "name": "Tiffany Longworth"
   ]
 }
 

--- a/lib/maintainers/runner.rb
+++ b/lib/maintainers/runner.rb
@@ -49,8 +49,8 @@ module Maintainers
     def validate_json(maintainers, quiet = false)
       begin
         JSON::Validator.validate!(maintainers_schema, maintainers)
-      rescue JSON::Schema::ValidationError => e
-        puts e unless quiet
+      rescue JSON::Schema::ValidationError, JSON::Schema::UriError => e
+        puts "JSON parsing failed or did not match schema\n#{e}\n#{maintainers}" unless quiet
         false
       end
     end

--- a/spec/maintainers_spec.rb
+++ b/spec/maintainers_spec.rb
@@ -5,3 +5,22 @@ describe Maintainers do
     expect(Maintainers::VERSION).not_to be nil
   end
 end
+
+describe 'badly formed json' do
+  it 'fails validation' do
+    maintainers_schema = JSON.parse(File.read('schema/MAINTAINERS-schema.json'))
+    # comma removed to make malformed input
+    maintainers_example = <<-EOF
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "maintained": false
+  "issues": "This repo is not maintained",
+  "people": []
+}
+    EOF
+
+    runner = Maintainers::Runner.new({})
+    expect(runner.validate_json(maintainers_example, true)).to be false
+  end
+end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -6,7 +6,7 @@ describe 'the maintainers schema' do
     json_meta_schema = JSON.parse(File.read('schema/json-meta-schema.json'))
     maintainers_schema = JSON.parse(File.read('schema/MAINTAINERS-schema.json'))
 
-    JSON::Validator.validate!(json_meta_schema, maintainers_schema)
+    expect(JSON::Validator.validate!(json_meta_schema, maintainers_schema)).to be true
   end
 end
 
@@ -15,7 +15,7 @@ describe 'the maintainers example' do
     maintainers_schema = JSON.parse(File.read('schema/MAINTAINERS-schema.json'))
     maintainers_example = JSON.parse(File.read('MAINTAINERS-example'))
 
-    JSON::Validator.validate!(maintainers_schema, maintainers_example)
+    expect(JSON::Validator.validate!(maintainers_schema, maintainers_example)).to be true
   end
 end
 
@@ -24,6 +24,6 @@ describe 'the maintainers unmaintained example' do
     maintainers_schema = JSON.parse(File.read('schema/MAINTAINERS-schema.json'))
     maintainers_example = JSON.parse(File.read('MAINTAINERS-unmaintained_example'))
 
-    JSON::Validator.validate!(maintainers_schema, maintainers_example)
+    expect(JSON::Validator.validate!(maintainers_schema, maintainers_example)).to be true
   end
 end


### PR DESCRIPTION
Certain types of misformed JSON caused a different exception to be thrown. Ensure we catch it, and add tests to cover the failure.

Without this change, a malformed JSON file would cause `maintainers report` to fail completely.
