### PR TITLE
Update lists report and add internal list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,6 +2,7 @@
   "version": 1,
   "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
   "issues": "https://github.com/puppetlabs/maintainers/issues",
+  "internal_list": "https://groups.google.com/a/puppet.com/forum/?hl=en#!forum/discuss-maintainers-maintainers",
   "people": [
     {
       "github": "mikaelsmith",

--- a/lib/maintainers/runner.rb
+++ b/lib/maintainers/runner.rb
@@ -178,19 +178,20 @@ module Maintainers
     end
 
     def report_lists_details(maintainers_files)
-      puts "it looks like you want to export a thingy!"
-      CSV.open("repo_report_#{Time.new.strftime("%Y-%m-%d_%H:%M:%S")}.csv", "wb") do |csv|
-        csv << ["repo_group","maintainer"]
+      report_name = "repo_report_#{Time.new.strftime("%Y-%m-%d_%H:%M:%S")}.csv"
+      CSV.open(report_name, "wb") do |csv|
+        csv << ["repo","repo_group","maintainer"]
         maintainers_files.keys.sort.each { |repo|
           maintainers = JSON.load( maintainers_files[repo] )
           list = maintainers['internal_list']
           if list 
             maintainers['people'].each { |person|
               name =  "#{person['email'] ? person['email'] : person['name'] ? person['name'] : person['github']}"
-              csv << [list, name ]
+              csv << [repo,list, name ]
             }
           end
         }
+      puts "Your report is called '#{report_name}'"
       end
     end
 


### PR DESCRIPTION
Previously, the csv from `maintainers report --verbose --details lists`
was populated with the internal list and the maintainer emails. This
change adds the repo name itself to the file. This will enable GitHub
team permissions to be set based on the MAINTAINERS files.

This change also adds a reference to the Google group the Maintainers maintainers are
associated with. By far, this is my most favorite new list name.